### PR TITLE
L8 tiling with aerosolQA

### DIFF
--- a/hls_libs/common/hls_hdfeos.c
+++ b/hls_libs/common/hls_hdfeos.c
@@ -869,34 +869,6 @@ int set_L8ang_sds_info(sds_info_t *all_sds,  int nsds,  l8ang_t *l8ang)
 	return(0);
 }
 
-//int set_aod_sds_info(sds_info_t *all_sds,  int nsds, aod_t *aod)
-//{
-//	char message[MSGLEN];
-//	char *dimnames[2] =  {"YDim_Grid", "XDim_Grid"};
-//	int iband = 0; 	/* There is only one SDS */
-//
-//	if (nsds != 1) {
-//		fprintf(stderr, "Only 1 SDS allowed in set_aod_sds_info()\n");
-//		return(1);
-//	}	
-//	iband = 0;
-//
-//	strcpy(all_sds[iband].name,  LASRC_AOD);
-//	strcpy(all_sds[iband].data_type_name, "DFNT_UINT8");
-//	all_sds[iband].data_type = DFNT_UINT8;
-//	strcpy(all_sds[iband].dimname[0], dimnames[0]);
-//	strcpy(all_sds[iband].dimname[1], dimnames[1]);
-//
-//	all_sds[iband].ulx = aod->ulx;
-//	all_sds[iband].uly = aod->uly;
-//	all_sds[iband].nrow = aod->nrow;
-//	all_sds[iband].ncol = aod->ncol;
-//	all_sds[iband].pixsz = HLS_PIXSZ; 
-//	all_sds[iband].zonecode =  atoi(aod->zonehem);
-//
-//	return(0);
-//}
-
 int angle_PutSpaceDefHDF(char *hdfname, sds_info_t sds[], int nsds)
 {
 	int32 sd_id;

--- a/hls_libs/common/hls_hdfeos.c
+++ b/hls_libs/common/hls_hdfeos.c
@@ -869,6 +869,34 @@ int set_L8ang_sds_info(sds_info_t *all_sds,  int nsds,  l8ang_t *l8ang)
 	return(0);
 }
 
+//int set_aod_sds_info(sds_info_t *all_sds,  int nsds, aod_t *aod)
+//{
+//	char message[MSGLEN];
+//	char *dimnames[2] =  {"YDim_Grid", "XDim_Grid"};
+//	int iband = 0; 	/* There is only one SDS */
+//
+//	if (nsds != 1) {
+//		fprintf(stderr, "Only 1 SDS allowed in set_aod_sds_info()\n");
+//		return(1);
+//	}	
+//	iband = 0;
+//
+//	strcpy(all_sds[iband].name,  LASRC_AOD);
+//	strcpy(all_sds[iband].data_type_name, "DFNT_UINT8");
+//	all_sds[iband].data_type = DFNT_UINT8;
+//	strcpy(all_sds[iband].dimname[0], dimnames[0]);
+//	strcpy(all_sds[iband].dimname[1], dimnames[1]);
+//
+//	all_sds[iband].ulx = aod->ulx;
+//	all_sds[iband].uly = aod->uly;
+//	all_sds[iband].nrow = aod->nrow;
+//	all_sds[iband].ncol = aod->ncol;
+//	all_sds[iband].pixsz = HLS_PIXSZ; 
+//	all_sds[iband].zonecode =  atoi(aod->zonehem);
+//
+//	return(0);
+//}
+
 int angle_PutSpaceDefHDF(char *hdfname, sds_info_t sds[], int nsds)
 {
 	int32 sd_id;

--- a/hls_libs/common/hls_hdfeos.h
+++ b/hls_libs/common/hls_hdfeos.h
@@ -91,4 +91,8 @@ int set_S2ang_sds_info(sds_info_t *all_sds,  int nsds,  s2ang_t *s2ang);
 int set_L8ang_sds_info(sds_info_t *all_sds,  int nsds,  l8ang_t *l8ang);
 int angle_PutSpaceDefHDF(char *hdfname, sds_info_t sds[], int nsds);
 
+/* AOD, for both Landsat and Sentinel-2.  And will reuse angle_PutSpaceDefHDF() */
+// Apr 15, 2021: Abandon. Now we have the 2 bits of aerosol level.
+// int set_aod_sds_info(sds_info_t *all_sds,  int nsds, aod_t *aod);
+
 #endif


### PR DESCRIPTION
1. Now the reflectance tiling considers aerosolQA bits in Fmask.   No change in commandline usage.
2.  There is slight change in hls_hdfeos.[hc], but it shouldn't cause a problem.