### PR TITLE
fix: Store under vi_outputname (HLS-VI.L30, not HLS.L30)

### DIFF
--- a/scripts/landsat-tile.sh
+++ b/scripts/landsat-tile.sh
@@ -60,7 +60,7 @@ set_output_names () {
   gibs_dir="${workingdir}/gibs"
   gibs_bucket_key="s3://${gibs_bucket}/L30/data/${year}${day_of_year}"
   bucket_key="s3://${bucket}/L30/data/${year}${day_of_year}/${outputname}"
-  vi_bucket_key="s3://${bucket}/L30_VI/data/${year}${day_of_year}/${outputname}"
+  vi_bucket_key="s3://${bucket}/L30_VI/data/${year}${day_of_year}/${vi_outputname}"
 }
 
 # Create array from pathrowlist


### PR DESCRIPTION
For Sentinel-2 we're storing data under prefixes named `[bucket]/S30_VI/data/[%Y%j]/HLS-VI.S30.[rest of path]` per,
https://github.com/NASA-IMPACT/hls-sentinel/blob/87422a75745190b6eb0790b706173ef43374ffea/scripts/sentinel.sh#L59

For Landsat we had created the templated `vi_outputname` but didn't include it in the `vi_bucket_key` used for the prefix. This PR fixes that issue