### PR TITLE
fix: Update ACCODE metadata to v3.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN cd ${SRC_DIR}/angle_tiling \
 RUN pip3 install click==7.1.2
 RUN pip3 install rio-cogeo==1.1.10 --no-binary rasterio --user
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-thumbnails@v1.3
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-metadata@v2.5
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-metadata@v2.7
 RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7
 RUN pip3 install libxml2-python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PREFIX=/usr/local \
     HDFLINK=" -lmfhdf -ldf -lm" \
     ECS_ENABLE_TASK_IAM_ROLE=true \
     PYTHONPATH="${PYTHONPATH}:${PREFIX}/lib/python3.6/site-packages" \
-    ACCODE=LaSRCL8V3.5.1 \
+    ACCODE="LaSRC v3.5.2" \
     LC_ALL=en_US.utf-8 \
     LANG=en_US.utf-8
 


### PR DESCRIPTION
This PR creates two changes so we reflect the current version of LaSRC in our product metadata,

* Define `ACCODE=LaSRC v3.5.2` as the default value for our Dockerfile (previously `LaSRCL8V3.5.1`). This should be a no-op but was included in this PR for consistency
* Update `hls-metadata` to a newer version so our CMR XML file contains the updated version (from `LaSRC v3.5.1` to `LaSRC v3.5.2`)