### PR TITLE
Revert to 3.5.1 since we can't upgrade hls-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PREFIX=/usr/local \
     HDFLINK=" -lmfhdf -ldf -lm" \
     ECS_ENABLE_TASK_IAM_ROLE=true \
     PYTHONPATH="${PYTHONPATH}:${PREFIX}/lib/python3.6/site-packages" \
-    ACCODE="LaSRC v3.5.1.0" \
+    ACCODE="LaSRC v3.5.1" \
     LC_ALL=en_US.utf-8 \
     LANG=en_US.utf-8
 


### PR DESCRIPTION
This PR reverts an update to use our forked version of LaSRC because we can't use the `hls-base` image it is contained in due to an apparent bug in Fmask 4.7 that affects Landsat. The update to LaSRC was a no-op for Landsat.

Kept in this PR is the fix to define the version of LaSRC in our metadata (`v3.5.1`, last published by USGS)